### PR TITLE
Remove SwiftyJSON

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-      .package(url: "https://github.com/SwiftyJSON/SwiftyJSON", from: "5.0.0"),
       .package(url: "https://github.com/IBM-Swift/SwiftyRequest", from: "3.1.0"),
       .package(url: "https://github.com/google/promises", from: "1.2.8"),
       
@@ -26,13 +25,12 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SwiftySlack",
-            dependencies: ["SwiftyRequest", "SwiftyJSON", "Promises"]),
+            dependencies: ["SwiftyRequest", "Promises"]),
         .testTarget(
             name: "SwiftySlackTests",
             dependencies: [
                 "SwiftySlack",
                 "Nimble",
-                "SwiftyJSON",
                 "SwiftyRequest",
                 "CwlPreconditionTesting"
             ]),

--- a/Sources/SwiftySlack/WebAPI.swift
+++ b/Sources/SwiftySlack/WebAPI.swift
@@ -268,11 +268,11 @@ public struct WebAPI {
     return Promise { fulfill, reject in
       request.messageBody = json
       request.responseData{ response in
-        switch response.result {
+        switch response {
         case .success(let retval):
           do {
             let decoder = JSONDecoder()
-            let receivedMessage = try decoder.decode(ReceivedMessage.self, from: retval)
+            let receivedMessage = try decoder.decode(ReceivedMessage.self, from: retval.body)
             if receivedMessage.ok != true {
               let error: Error = MessageError(rawValue: receivedMessage.error ?? "") ?? SwiftySlackError.slackError("Unrecognized error")
               reject(error)
@@ -301,11 +301,11 @@ public struct WebAPI {
         reject(error)
       }
       request.responseData{ response in
-        switch response.result {
+        switch response {
         case .success(let retval):
           do {
             let decoder = JSONDecoder()
-              let receivedMessage = try decoder.decode(ReceivedMessage.self, from: retval)
+              let receivedMessage = try decoder.decode(ReceivedMessage.self, from: retval.body)
             if receivedMessage.ok != true {
               let error: Error = MessageError(rawValue: receivedMessage.error ?? "") ?? SwiftySlackError.slackError("Unrecognized error")
               reject(error)


### PR DESCRIPTION
SwiftyJSON is giving me issue on Linux. I made this PR to remove it it wasn't used a lot anyway.

```
remote: [2/475] Compiling SwiftyJSON SwiftyJSON.swift
remote: /tmp/build_c332ee069a0b27c533c8ae8a73ecd078/.build/checkouts/SwiftyJSON/Source/SwiftyJSON/SwiftyJSON.swift:1215:51: error: ambiguous use of operator '<'
remote:     case (.number, .number): return lhs.rawNumber < rhs.rawNumber
remote:                                                   ^
remote: /tmp/build_c332ee069a0b27c533c8ae8a73ecd078/.build/checkouts/SwiftyJSON/Source/SwiftyJSON/SwiftyJSON.swift:1251:6: note: found this candidate
remote: func < (lhs: NSNumber, rhs: NSNumber) -> Bool {
remote:      ^
remote: Foundation.NSNumber:2:24: note: found this candidate
remote:     public static func < (lhs: NSNumber, rhs: NSNumber) -> Bool
remote:                        ^
```