### PR TITLE
Make ReceivedMessage and tsOrNot available externally

### DIFF
--- a/Sources/SwiftySlack/Message.swift
+++ b/Sources/SwiftySlack/Message.swift
@@ -35,7 +35,7 @@ public class Message: Encodable {
   public internal(set) var post_at: String?
   public internal(set) var scheduled_message_id: String?
   
-  internal var tsOrNot: Bool = false
+  public var tsOrNot: Bool = false
   
   
   // MARK: Constructors

--- a/Sources/SwiftySlack/Message.swift
+++ b/Sources/SwiftySlack/Message.swift
@@ -160,23 +160,23 @@ public class Message: Encodable {
   }
 }
 
-internal class ReceivedMessage: Decodable {
-  internal struct MetadataResponse: Decodable {
-    internal var warnings: [String] = []
-    internal var messages: [String] = []
+public class ReceivedMessage: Decodable {
+  public struct MetadataResponse: Decodable {
+    public var warnings: [String] = []
+    public var messages: [String] = []
   }
-  internal var ok: Bool
-  internal var warning: String?
-  internal var response_metadata: MetadataResponse?
-  internal var ts: String?
-  internal var channel: String
-  internal var error: String?
-  internal var post_at: String?
-  internal var scheduled_message_id: String?
+  public var ok: Bool
+  public var warning: String?
+  public var response_metadata: MetadataResponse?
+  public var ts: String?
+  public var channel: String
+  public var error: String?
+  public var post_at: String?
+  public var scheduled_message_id: String?
   
-  internal var message: Message?
+  public var message: Message?
   
-  internal func update(with message: Message) -> Message {
+  public func update(with message: Message) -> Message {
     message.channel = channel
     message.thread_ts = ts
     message.scheduled_message_id = scheduled_message_id

--- a/Sources/SwiftySlack/Message.swift
+++ b/Sources/SwiftySlack/Message.swift
@@ -196,7 +196,7 @@ public class ReceivedMessage: Decodable {
     case scheduled_message_id
   }
   
-  required init(from decoder: Decoder) throws {
+  required public init(from decoder: Decoder) throws {
     let values = try decoder.container(keyedBy: CodingKeys.self)
     ok = try values.decode(Bool.self, forKey: .ok)
     warning = try? values.decode(String?.self, forKey: .warning)


### PR DESCRIPTION
Hi @mbarnach,

In order to have more flexibility with the networking client I have to make `ReceivedMessage` and `tsOrNot` publicly available.