### PR TITLE
Adds function builder to Message class

### DIFF
--- a/Sources/SwiftySlack/Message.swift
+++ b/Sources/SwiftySlack/Message.swift
@@ -160,6 +160,68 @@ public class Message: Encodable {
   }
 }
 
+@_functionBuilder
+struct MessageBuilder {
+    static func buildBlock(_ block: Block) -> Block {
+        block
+    }
+
+    static func buildBlock(_ blocks: Block?...) -> [Block] {
+        blocks.compactMap({ $0 })
+    }
+
+    static func buildIf(_ value: Block?) -> Block? {
+        value
+    }
+
+    static func buildEither(first: Block) -> Block {
+        first
+    }
+
+    static func buildEither(second: Block) -> Block {
+        second
+    }
+}
+
+extension Message {
+    convenience init(to channel: String,
+                     alternateText text: String?,
+                     @MessageBuilder blocks: () -> [Block]) {
+        self.init(blocks: blocks(), to: channel, alternateText: text)
+    }
+
+    convenience init(to channel: String,
+                     alternateText text: String?,
+                     as as_user: Bool? = nil,
+                     emoji icon_emoji: String? = nil,
+                     url icon_url: URL? = nil,
+                     link link_names: Bool? = nil,
+                     useMarkdown mrkdwn: Bool? = nil,
+                     parse: Parse? = nil,
+                     reply_broadcast: Bool? = nil,
+                     reply thread_ts: String? = nil,
+                     unfurl_links: Bool? = nil,
+                     unfurl_media: Bool? = nil,
+                     username: String? = nil,
+                     @MessageBuilder blocks: () -> [Block]) {
+        self.init(blocks: blocks(),
+                  to: channel,
+                  alternateText: text,
+                  as: as_user,
+                  emoji: icon_emoji,
+                  url: icon_url,
+                  link: link_names,
+                  useMarkdown: mrkdwn,
+                  parse: parse,
+                  reply_broadcast: reply_broadcast,
+                  reply: thread_ts,
+                  unfurl_links: unfurl_links,
+                  unfurl_media: unfurl_media,
+                  username: username
+        )
+    }
+}
+
 internal class ReceivedMessage: Decodable {
   internal struct MetadataResponse: Decodable {
     internal var warnings: [String] = []

--- a/Tests/SwiftySlackTests/MessageTests.swift
+++ b/Tests/SwiftySlackTests/MessageTests.swift
@@ -101,7 +101,100 @@ final class MessageTests: XCTestCase {
     expect{ answer.error }.to(beNil())
     
   }
-  
+
+  func testMessageBuilder() {
+    let message = Message(to: channel, alternateText: #function) {
+      SectionBlock(text: MarkdownText("You have a new request:\n*<google.com|Fred Enriquez - Time Off request>*"))
+      DividerBlock()
+      SectionBlock(text: MarkdownText("*Type:*\nPaid time off\n*When:*\nAug 10-Aug 13\n*Hours:* 16.0 (2 days)\n*Remaining balance:* 32.0 hours (4 days)\n*Comments:* \"Family in town, going camping!\""),
+                   accessory: ImageElement(image_url: URL(string: "https://api.slack.com/img/blocks/bkb_template_images/approvalsNewDevice.png")!,
+                                           alt_text: "computer thumbnail"))
+      ContextBlock(elements: [
+        ContextBlock.ContextElement(image: ImageElement(image_url: URL(string: "https://api.slack.com/img/blocks/bkb_template_images/notificationsWarningIcon.png")!,
+                                                        alt_text: "notifications warning icon")),
+        ContextBlock.ContextElement(text: MarkdownText("*Conflicts with Team Huddle: 4:15-4:30pm*"))
+      ]
+      )
+      ActionsBlock(elements: [
+        ButtonElement(text: PlainText(text: "Approve", emoji: true),
+                      value: "click_me_123",
+                      style: .primary),
+        ButtonElement(text: PlainText(text: "Deny", emoji: true),
+                      value: "click_me_123",
+                      style: .danger)
+        ]
+      )
+    }
+
+    let expectedJSON = JSON(parseJSON: """
+      [
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "You have a new request:\\n*<google.com|Fred Enriquez - Time Off request>*"
+          }
+        },
+        {
+          "type": "divider"
+        },
+        {
+          "type": "section",
+          "text": {
+            "type": "mrkdwn",
+            "text": "*Type:*\\nPaid time off\\n*When:*\\nAug 10-Aug 13\\n*Hours:* 16.0 (2 days)\\n*Remaining balance:* 32.0 hours (4 days)\\n*Comments:* \\"Family in town, going camping!\\""
+          },
+          "accessory": {
+            "type": "image",
+            "image_url": "https://api.slack.com/img/blocks/bkb_template_images/approvalsNewDevice.png",
+            "alt_text": "computer thumbnail"
+          }
+        },
+        {
+          "type": "context",
+          "elements": [
+            {
+              "type": "image",
+              "image_url": "https://api.slack.com/img/blocks/bkb_template_images/notificationsWarningIcon.png",
+              "alt_text": "notifications warning icon"
+            },
+            {
+              "type": "mrkdwn",
+              "text": "*Conflicts with Team Huddle: 4:15-4:30pm*"
+            }
+          ]
+        },
+        {
+          "type": "actions",
+          "elements": [
+            {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "emoji": true,
+                "text": "Approve"
+              },
+              "style": "primary",
+              "value": "click_me_123"
+            },
+            {
+              "type": "button",
+              "text": {
+                "type": "plain_text",
+                "emoji": true,
+                "text": "Deny"
+              },
+              "style": "danger",
+              "value": "click_me_123"
+            }
+          ]
+        }
+      ]
+      """)
+
+    expect{ jsonEncode(object: message.blocks) } == expectedJSON
+  }
+
   func testTemplateApprovalMessage() {
     let section1 = SectionBlock(text: MarkdownText("You have a new request:\n*<fakeLink.toEmployeeProfile.com|Fred Enriquez - New device request>*"))
     


### PR DESCRIPTION
This pull request adds a way to pass Blocks to Message initializer via a trailing closure, similar to SwiftUI by using @_function builder.
